### PR TITLE
Added forgotten verb in sec 5

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,2 @@
+All documents in this Repository are licensed by contributors under the [W3C Document
+License](https://www.w3.org/Consortium/Legal/copyright-documents).


### PR DESCRIPTION
Fixes #12 

Sentence in Sec 5 has verb left out; nonsensical:
“The transaction examples in this section basic ways in which Verifiable Claims might be used.”

Suggest adding verb ‘show’:
“The transaction examples in this section show basic ways in which verifiable claims might be used.”