### PR TITLE
Reformat VC list in Citizenship Focal Use Case

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,12 +674,20 @@ dl.dl-horizontal > dd {
           evidence. After processing the application, Sam is issued both a traditional passport 
           and a new digital passport.</p>
       <h3>Verifiable Credentials</h3>
-        <ul>
-          <li>Birth Certificate</li>
-          <li>Marriage License</li>
-          <li>Mother’s Passport</li>
-          <li>Sam’s Passport</li>
-        </ul>
+        <dl class="dl-horizontal">
+          <dt>Birth Certificate</dt>
+          <dd>Establishes relationship to mother with maiden name</dd>
+          
+          <dt>Marriage License</dt>
+          <dd>Establishes mother's name change</dd>
+          
+          <dt>Mother’s Passport</dt>
+          <dd>Establishes mothers US Citizenship</dd>
+          
+          <dt>Sam’s Passport</dt>            
+          <dd>Establishes <span class="issue">Sam is the child in the birth certificate</span></dd>
+        </dl>
+        
       <h3>Verifiable Presentation</h3>
         <p>A Verifiable Presentation which includes those three credentials, adds his name, photo, 
           and demographic data along with the assertion that</p>


### PR DESCRIPTION
Implement format of verified credentials that allows us to explicitly document the value of the credential in the presentation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-use-cases/pull/69.html" title="Last updated on May 31, 2018, 2:05 PM GMT (209c8d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-use-cases/69/0737c0b...209c8d5.html" title="Last updated on May 31, 2018, 2:05 PM GMT (209c8d5)">Diff</a>