### PR TITLE
Reformat credential list in Focal Use Cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -730,7 +730,7 @@ dl.dl-horizontal > dd {
             </ul>
         </ol>
     </section>
-    <section>
+    <!-- <section>
       <h2>Expert Dive Instructor</h2>
       <h3>Background</h3>
       <h3>Distinction</h3>
@@ -739,7 +739,7 @@ dl.dl-horizontal > dd {
       <h3>Verifiable Presentation</h3>
       <h3>Trust Hierarchy</h3>
       <h3>Threat model</h3>
-    </section>
+    </section> -->
     <section>
       <h2>International Travel with minor and upgrade</h2>
         <p></p>

--- a/index.html
+++ b/index.html
@@ -764,21 +764,28 @@ dl.dl-horizontal > dd {
         class. HappyAir issues a Verifiable Credential redeemable for a first class upgrade on an
         international flight.</p>
       <h3>Verifiable Credentials</h3>
-        <p class="issue">Reformat section to include the value/purpose of each credential.</p>
-        <ul>
-          <li>Traveling Parent passport</li>
-          <li>Minor passport</li>
-          <li>Permission from non-traveling parent </li>
-          <ul>
-            <li>Parents are the holders of the passport credential</li>
-            <li>Parents must present the passport credential</li>
-            <li>In order for one parent to present the passport credential alone, they must give 
-              mutual permission.</li>
-            <li>This replaces the role of a notarized permission document</li>
-          </ul>
-          <li>Coupon for upgrading ticket to first class. <span class="note">This introduces a 
-            commerce bound credential.</span></li>
-        </ul>
+        <dl class="dl-horizontal">
+          <dt>Traveling Parent passport</dt>
+          <dd>Establishes identity of the traveling parent</dd>
+          
+          <dt>Minor passport</dt>
+          <dd>Establishes identity of the minor</dd>
+          
+          <dt>Permission from non-traveling parent </dt>
+          <dd>
+            <ul>
+              <li>Parents are the holders of the passport credential</li>
+              <li>Parents must present the passport credential</li>
+              <li>In order for one parent to present the passport credential alone, they must give 
+                mutual permission.</li>
+              <li>This replaces the role of a notarized permission document</li>
+            </ul>
+          </dd>
+          
+          <dt>Coupon for upgrading ticket to first class</dt>
+          <dd>Introduces commercial value in a verifiable credential </dd>
+        </dl>
+        
       <h3>Verifiable Presentation</h3>
         <p>Submitted to HappyAir, includes assertion of permission and Frequent Flyer coupon. </p>
       <h3>Trust Hierarchy</h3>

--- a/index.html
+++ b/index.html
@@ -674,12 +674,20 @@ dl.dl-horizontal > dd {
           evidence. After processing the application, Sam is issued both a traditional passport 
           and a new digital passport.</p>
       <h3>Verifiable Credentials</h3>
-        <ul>
-          <li>Birth Certificate</li>
-          <li>Marriage License</li>
-          <li>Mother’s Passport</li>
-          <li>Sam’s Passport</li>
-        </ul>
+        <dl class="dl-horizontal">
+          <dt>Birth Certificate</dt>
+          <dd>Establishes relationship to mother with maiden name</dd>
+          
+          <dt>Marriage License</dt>
+          <dd>Establishes mother's name change</dd>
+          
+          <dt>Mother’s Passport</dt>
+          <dd>Establishes mothers US Citizenship</dd>
+          
+          <dt>Sam’s Passport</dt>            
+          <dd>Establishes <span class="issue">Sam is the child in the birth certificate</span></dd>
+        </dl>
+        
       <h3>Verifiable Presentation</h3>
         <p>A Verifiable Presentation which includes those three credentials, adds his name, photo, 
           and demographic data along with the assertion that</p>


### PR DESCRIPTION
Use a format that allow us to explicitly document the value of each credential in a presentation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-use-cases/pull/70.html" title="Last updated on May 31, 2018, 2:24 PM GMT (e45dacc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-use-cases/70/0737c0b...e45dacc.html" title="Last updated on May 31, 2018, 2:24 PM GMT (e45dacc)">Diff</a>