### PR TITLE
grammar: Avoid “comprised of”

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@ counterparties, without being locked into proprietary platforms.
     <section>
       <h3>Use case model</h3>
       <p>
-This document presents an aggregate use case model, comprised of Needs, Roles,
+This document presents an aggregate use case model, comprising Needs, Roles,
 Tasks, and Sequences. Taken together, these models define the use cases that
 the Verifiable Claims Working Group has addressed.
       </p>

--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@ counterparties, without being locked into proprietary platforms.
     <section>
       <h3>Use case model</h3>
       <p>
-This document presents an aggregate use case model, comprising Needs, Roles,
+This document presents an aggregate use case model, composed of Needs, Roles,
 Tasks, and Sequences. Taken together, these models define the use cases that
 the Verifiable Claims Working Group has addressed.
       </p>


### PR DESCRIPTION
Just to be safe of possible criticism, it might be better to avoid using “comprised of”.

### References

* https://www.grammarly.com/blog/comprise-vs-compose/
* https://en.wikipedia.org/wiki/Comprised_of


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kirelagin/vc-use-cases/pull/123.html" title="Last updated on Jun 8, 2021, 11:27 PM UTC (67d9565)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-use-cases/123/8db0391...kirelagin:67d9565.html" title="Last updated on Jun 8, 2021, 11:27 PM UTC (67d9565)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kirelagin/vc-use-cases/pull/123.html" title="Last updated on Apr 14, 2023, 5:43 PM UTC (03492b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-use-cases/123/8db0391...kirelagin:03492b5.html" title="Last updated on Apr 14, 2023, 5:43 PM UTC (03492b5)">Diff</a>